### PR TITLE
Don't recalculate when reloading

### DIFF
--- a/abics/mc_mpi.py
+++ b/abics/mc_mpi.py
@@ -262,6 +262,7 @@ class TemperatureRX_MPI(ParallelMC):
         self.obs_save = []
         self.Trank_hist = []
         self.kT_hist = []
+        self.Lreload = False
 
     def reload(self):
         self.rank_to_T = pickle_load("rank_to_T.pickle")
@@ -273,6 +274,7 @@ class TemperatureRX_MPI(ParallelMC):
         self.kT_hist0 = numpy_load(os.path.join(str(self.rank), "kT_hist.npy"))
         rand_state = pickle_load(os.path.join(str(self.rank), "rand_state.pickle"))
         rand.setstate(rand_state)
+        self.Lreload = True
 
     def find_procrank_from_Trank(self, Trank):
         """
@@ -360,7 +362,6 @@ class TemperatureRX_MPI(ParallelMC):
         observer=observer_base(),
         subdirs=True,
         save_obs=True,
-        reload=False,
     ):
         """
 
@@ -391,7 +392,7 @@ class TemperatureRX_MPI(ParallelMC):
                 pass
             os.chdir(str(self.rank))
         self.accept_count = 0
-        if not reload:
+        if not self.Lreload:
             self.mycalc.energy = self.mycalc.model.energy(self.mycalc.config)
         with open(os.devnull, "w") as f:
             test_observe = observer.observe(self.mycalc, f, lprint=False)

--- a/abics/mc_mpi.py
+++ b/abics/mc_mpi.py
@@ -268,6 +268,7 @@ class TemperatureRX_MPI(ParallelMC):
         self.mycalc.kT = self.kTs[self.rank_to_T[self.rank]]
         self.mycalc.config = pickle_load(os.path.join(str(self.rank), "calc.pickle"))
         self.obs_save0 = numpy_load(os.path.join(str(self.rank), "obs_save.npy"))
+        self.mycalc.energy = self.obs_save0[-1,0]
         self.Trank_hist0 = numpy_load(os.path.join(str(self.rank), "Trank_hist.npy"))
         self.kT_hist0 = numpy_load(os.path.join(str(self.rank), "kT_hist.npy"))
         rand_state = pickle_load(os.path.join(str(self.rank), "rand_state.pickle"))
@@ -359,6 +360,7 @@ class TemperatureRX_MPI(ParallelMC):
         observer=observer_base(),
         subdirs=True,
         save_obs=True,
+        reload=False,
     ):
         """
 
@@ -389,7 +391,8 @@ class TemperatureRX_MPI(ParallelMC):
                 pass
             os.chdir(str(self.rank))
         self.accept_count = 0
-        self.mycalc.energy = self.mycalc.model.energy(self.mycalc.config)
+        if not reload:
+            self.mycalc.energy = self.mycalc.model.energy(self.mycalc.config)
         with open(os.devnull, "w") as f:
             test_observe = observer.observe(self.mycalc, f, lprint=False)
         if hasattr(test_observe, "__iter__"):

--- a/abics/scripts/main.py
+++ b/abics/scripts/main.py
@@ -114,6 +114,7 @@ def main_impl(tomlfile):
         print_frequency,
         observer=default_observer(comm, Lreload),
         subdirs=True,
+        reload=Lreload,
     )
 
 

--- a/abics/scripts/main.py
+++ b/abics/scripts/main.py
@@ -114,7 +114,6 @@ def main_impl(tomlfile):
         print_frequency,
         observer=default_observer(comm, Lreload),
         subdirs=True,
-        reload=Lreload,
     )
 
 


### PR DESCRIPTION
# Problem:
When reloading, VASP fails at update_info_by_structure in vasp.py on the first MC step. 

# Reason:
The first MC step after reloading is a recalculation of the final relaxed structure of the previous run. This fails because the final structure is a result of Output.get_results and does not contain "seldyn" information required by update_info_by_structure.

# Proposed fix:
Don't perform recalculation when reloading, and read in the energy from the last step. 

Another possibility is to allow update_info_by_structure without "seldyn", but I think that is a bad idea because that can be inconsistent if some atoms were fixed by "seldyn" in the previous run.