### PR TITLE
perturb only unfixed components

### DIFF
--- a/abics/applications/latgas_abinitio_interface/run_base_mpi.py
+++ b/abics/applications/latgas_abinitio_interface/run_base_mpi.py
@@ -26,6 +26,8 @@ from mpi4py import MPI
 
 import numpy as np
 
+from .model_setup import perturb_structure
+
 
 class runner(object):
     """
@@ -141,7 +143,7 @@ class runner(object):
             Structure of compounds after optimization
         """
         if self.perturb:
-            structure.perturb(self.perturb)
+            perturb_structure(structure, self.perturb)
         solverinput = self.base_solver_input
         solverinput.update_info_by_structure(structure)
         self.run.submit(self.solver_name, solverinput, output_dir)

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -23,7 +23,7 @@ from numpy.linalg import inv
 from pymatgen import Structure
 
 from abics.mc_mpi import RXParams
-from abics.applications.latgas_abinitio_interface.model_setup import group
+from abics.applications.latgas_abinitio_interface.model_setup import group, perturb_structure
 from abics.applications.latgas_abinitio_interface.defect import (
     defect_config,
     DFTConfigParams,
@@ -93,6 +93,10 @@ class TestInput(unittest.TestCase):
         self.assertTrue(
             (spinel_config.base_structure.site_properties["seldyn"] == seldyns).all()
         )
+
+        perturb_structure(spinel_config.base_structure, 0.1)
+        self.assertNotEqual(spinel_config.base_structure.sites[0].coords[0], 0.0)
+        self.assertEqual(spinel_config.base_structure.sites[0].coords[2], 0.0)
 
         gs = [
             group("Al", ["Al"], coords=[[[0.0, 0.0, 0.0]]]),


### PR DESCRIPTION
`Structure.perturb` is replaced with `model_setup.perturb_structure`, where only unfixed components will be perturbed