### PR TITLE
fix expand_path feature for command path

### DIFF
--- a/abics/applications/latgas_abinitio_interface/params.py
+++ b/abics/applications/latgas_abinitio_interface/params.py
@@ -16,7 +16,7 @@
 
 import os
 
-from ...util import expand_path
+from ...util import expand_path, expand_cmd_path
 
 
 class DFTParams:
@@ -56,7 +56,10 @@ class DFTParams:
             map(lambda x: expand_path(x, os.getcwd()), base_input_dir)
         )
         params.solver = d["type"]
-        params.path = expand_path(d["path"], os.getcwd())
+
+        #params.path = expand_path(d["path"], os.getcwd())
+        params.path = expand_cmd_path(d["path"])
+
         params.perturb = d.get("perturb", 0.1)
         params.solver_run_scheme = d.get("run_scheme", "mpi_spawn_ready")
         params.ignore_species = d.get("ignore_species", None)

--- a/abics/util.py
+++ b/abics/util.py
@@ -136,6 +136,10 @@ def expand_path(path, basedir):
         path = os.path.join(basedir, path)
     return path
 
+def expand_cmd_path(path):
+    path = os.path.expanduser(path)
+    path = os.path.expandvars(path)
+    return path
 
 def pickle_dump(data, filename):
     with open(filename, 'wb') as f:


### PR DESCRIPTION
expanding into absolute path is suppressed for command paths (namely that for predict.x). it would be sufficient that they are resolved on PATH environment variable.