### PR TITLE
change class names

### DIFF
--- a/abics/applications/latgas_abinitio_interface/aenet.py
+++ b/abics/applications/latgas_abinitio_interface/aenet.py
@@ -124,7 +124,7 @@ def from_XSF(input_string):
     return s
 
 
-class aenetSolver(SolverBase):
+class AenetSolver(SolverBase):
     """
     This class defines the aenet solver.
     """
@@ -138,10 +138,10 @@ class aenetSolver(SolverBase):
         path_to_solver : str
                       Path to the solver.
         """
-        super(aenetSolver, self).__init__(path_to_solver)
+        super(AenetSolver, self).__init__(path_to_solver)
         self.path_to_solver = path_to_solver
-        self.input = aenetSolver.Input(ignore_species, run_scheme)
-        self.output = aenetSolver.Output()
+        self.input = AenetSolver.Input(ignore_species, run_scheme)
+        self.output = AenetSolver.Output()
 
     def name(self):
         return "aenet"

--- a/abics/applications/latgas_abinitio_interface/defect.py
+++ b/abics/applications/latgas_abinitio_interface/defect.py
@@ -17,7 +17,7 @@
 import typing
 from typing import Any, Dict, List, MutableMapping
 
-from pymatgen.core import Lattice
+from pymatgen.core import Lattice, Structure
 
 from .model_setup import Config, DefectSublattice, base_structure
 

--- a/abics/applications/latgas_abinitio_interface/defect.py
+++ b/abics/applications/latgas_abinitio_interface/defect.py
@@ -14,16 +14,26 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see http://www.gnu.org/licenses/.
 
+import typing
+from typing import Any, Dict, List, MutableMapping
+
 from pymatgen.core import Lattice
 
-from .model_setup import config, defect_sublattice, base_structure
+from .model_setup import Config, DefectSublattice, base_structure
 
 from abics.exception import InputError
 from abics.util import read_matrix
 
 
 class DFTConfigParams:
-    def __init__(self, dconfig):
+
+    lat: Lattice
+    supercell: List[int]
+    base_structure: Structure
+    defect_sublattices: List[DefectSublattice]
+    num_defects: List[Dict[str, int]]
+
+    def __init__(self, dconfig: MutableMapping[str, Any]) -> None:
         """
         Get information from dictionary
 
@@ -37,12 +47,16 @@ class DFTConfigParams:
             dconfig = dconfig["config"]
 
         if "unitcell" not in dconfig:
-            raise InputError('"unitcell" is not found in the "config" section.')
+            raise InputError('"config.unitcell" is not found in the "config" section.')
         self.lat = Lattice(read_matrix(dconfig["unitcell"]))
 
-        self.supercell = dconfig.get("supercell", [1, 1, 1])
+        self.supercell = typing.cast(List[int], dconfig.get("supercell", [1, 1, 1]))
+        if not isinstance(self.supercell, list):
+            raise InputError('"config.supercell" should be a list of integers')
 
         constraint_module = dconfig.get("constraint_module", False)
+        if not isinstance(constraint_module, bool):
+            raise InputError('"config.constraint_module" should be true or false')
         if constraint_module:
             import os, sys
 
@@ -60,7 +74,7 @@ class DFTConfigParams:
         if "defect_structure" not in dconfig:
             raise InputError('"defect_structure" is not found in the "config" section.')
         self.defect_sublattices = [
-            defect_sublattice.from_dict(ds) for ds in dconfig["defect_structure"]
+            DefectSublattice.from_dict(ds) for ds in dconfig["defect_structure"]
         ]
         self.num_defects = [
             {g["name"]: g["num"] for g in ds["groups"]}
@@ -68,11 +82,11 @@ class DFTConfigParams:
         ]
 
     @classmethod
-    def from_dict(cls, d):
+    def from_dict(cls, d: MutableMapping) -> "DFTConfigParams":
         return cls(d)
 
     @classmethod
-    def from_toml(cls, f):
+    def from_toml(cls, f: str) -> "DFTConfigParams":
         """
 
         Get information from toml file.
@@ -92,7 +106,7 @@ class DFTConfigParams:
         return cls(toml.load(f))
 
 
-def defect_config(cparam: DFTConfigParams):
+def defect_config(cparam: DFTConfigParams) -> Config:
     """
     Get configuration information
 
@@ -106,7 +120,7 @@ def defect_config(cparam: DFTConfigParams):
     spinel_config: config object
         spinel configure object
     """
-    spinel_config = config(
+    spinel_config = Config(
         cparam.base_structure,
         cparam.defect_sublattices,
         cparam.num_defects,

--- a/abics/applications/latgas_abinitio_interface/map2perflat.py
+++ b/abics/applications/latgas_abinitio_interface/map2perflat.py
@@ -26,7 +26,7 @@ def map2perflat(
     perf_st = perf_st.copy()
     N = perf_st.num_sites
     seldyn = np.array(
-        perf_st.site_properties.get("seldyn", np.ones((N, 3))), dtype=np.float
+        perf_st.site_properties.get("seldyn", np.ones((N, 3))), dtype=np.float64
     )
     perf_st.replace_species(vac_spaceholder)
     mapping = naive_mapping(st, perf_st)

--- a/abics/applications/latgas_abinitio_interface/model_setup.py
+++ b/abics/applications/latgas_abinitio_interface/model_setup.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see http://www.gnu.org/licenses/.
 
+from typing import List
+
 from itertools import product
 import sys
 import os
@@ -645,7 +647,7 @@ class Config:
             comparator=FrameworkComparator(),
         )
 
-        self.calc_history = []
+        self.calc_history: List = []
         self.cellsize = cellsize
         self.base_structure = base_structure
         self.constraint_func = constraint_func

--- a/abics/applications/latgas_abinitio_interface/run_base_mpi.py
+++ b/abics/applications/latgas_abinitio_interface/run_base_mpi.py
@@ -58,7 +58,7 @@ class Run(metaclass=ABCMeta):
         ...
 
 
-class Run_mpispawn(Run):
+class RunMpispawn(Run):
     """
     Invoker via mpi_comm_spawn
 
@@ -161,7 +161,7 @@ class Run_mpispawn(Run):
         return 0
 
 
-class Run_mpispawn_ready(Run):
+class RunMpispawnReady(Run):
     """
     Invoker via mpi_comm_spawn for solvers which is MPI_Comm_spawn-ready
 
@@ -309,7 +309,7 @@ class Run_mpispawn_ready(Run):
         return 0
 
 
-class Run_mpispawn_wrapper(Run):
+class RunMpispawnWrapper(Run):
     """
     Invoker via mpi_comm_spawn
 
@@ -446,7 +446,7 @@ class Run_mpispawn_wrapper(Run):
         return 0
 
 
-class Run_subprocess(Run):
+class RunSubprocess(Run):
     """
     Invoker via subprocess
 
@@ -527,7 +527,7 @@ class Run_subprocess(Run):
         return 0
 
 
-class Run_function(Run):
+class RunFunction(Run):
     """
     Invoker via function call
 
@@ -692,23 +692,23 @@ class Runner:
             )
             sys.exit(1)
         if solver_run_scheme == "mpi_spawn_ready":
-            self.run = Run_mpispawn_ready(
+            self.run = RunMpispawnReady(
                 self.path_to_solver, nprocs_per_solver, nthreads_per_proc, comm
             )
         elif solver_run_scheme == "mpi_spawn":
-            self.run = Run_mpispawn(
+            self.run = RunMpispawn(
                 self.path_to_solver, nprocs_per_solver, nthreads_per_proc, comm
             )
         elif solver_run_scheme == "mpi_spawn_wrapper":
-            self.run = Run_mpispawn_wrapper(
+            self.run = RunMpispawnWrapper(
                 self.path_to_solver, nprocs_per_solver, nthreads_per_proc, comm
             )
         elif solver_run_scheme == "subprocess":
-            self.run = Run_subprocess(
+            self.run = RunSubprocess(
                 self.path_to_solver, nprocs_per_solver, nthreads_per_proc, comm
             )
         elif solver_run_scheme == "function":
-            self.run = Run_function(
+            self.run = RunFunction(
                 self.path_to_solver, nprocs_per_solver, nthreads_per_proc, comm
             )
         else:
@@ -925,8 +925,8 @@ if __version__ < "3":
     runner = Runner
     runner_multistep = RunnerMultistep
     runner_ensemble = RunnerEnsemble
-    run_mpispawn = Run_mpispawn
-    run_mpispawn_ready = Run_mpispawn_ready
-    run_mpispawn_wrapper = Run_mpispawn_wrapper
-    run_subprocess = Run_subprocess
-    run_function = Run_function
+    run_mpispawn = RunMpispawn
+    run_mpispawn_ready = RunMpispawnReady
+    run_mpispawn_wrapper = RunMpispawnWrapper
+    run_subprocess = RunSubprocess
+    run_function = RunFunction

--- a/abics/exception.py
+++ b/abics/exception.py
@@ -27,7 +27,7 @@ class InputError(Error):
     message: str
         explanation
     """
-    def __init__(self, message):
+    def __init__(self, message: str):
         self.message = message
 
 
@@ -39,5 +39,5 @@ class MatrixParseError(Error):
     message: str
         explanation
     """
-    def __init__(self, message):
+    def __init__(self, message: str):
         self.message = message

--- a/abics/mc_mpi.py
+++ b/abics/mc_mpi.py
@@ -23,7 +23,7 @@ from mpi4py import MPI
 import numpy as np
 import numpy.random as rand
 
-from abics.mc import observer_base, obs_decode, verylargeint
+from abics.mc import ObserverBase, obs_decode, verylargeint
 from abics.util import pickle_dump, pickle_load, numpy_save, numpy_load
 
 
@@ -541,7 +541,7 @@ class EmbarrassinglyParallelSampling:
         nsteps,
         sample_frequency=verylargeint,
         print_frequency=verylargeint,
-        observer=observer_base(),
+        observer=ObserverBase(),
         subdirs=True,
         save_obs=True,
     ):
@@ -684,7 +684,7 @@ class ParallelMC(object):
         mytemp = kTs[self.rank]
         self.mycalc = MCalgo(model, mytemp, myconfig)
 
-    def run(self, nsteps, sample_frequency, observer=observer_base()):
+    def run(self, nsteps, sample_frequency, observer=ObserverBase()):
         """
 
         Parameters
@@ -877,7 +877,7 @@ class TemperatureRX_MPI(ParallelMC):
         RXtrial_frequency,
         sample_frequency=verylargeint,
         print_frequency=verylargeint,
-        observer=observer_base(),
+        observer=ObserverBase(),
         subdirs=True,
         save_obs=True,
     ):

--- a/abics/mc_mpi.py
+++ b/abics/mc_mpi.py
@@ -14,8 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see http://www.gnu.org/licenses/.
 
+from typing import Type
+
 import os
-from shutil import move
 import sys
 
 from mpi4py import MPI
@@ -23,7 +24,7 @@ from mpi4py import MPI
 import numpy as np
 import numpy.random as rand
 
-from abics.mc import ObserverBase, obs_decode, verylargeint
+from abics.mc import ObserverBase, verylargeint, MCAlgorithm, Model
 from abics.util import pickle_dump, pickle_load, numpy_save, numpy_load
 
 
@@ -415,7 +416,7 @@ class RXParams:
         return cls.from_dict(d["sampling"])
 
 
-def RX_MPI_init(rxparams, dftparams=None):
+def RX_MPI_init(rxparams: RXParams, dftparams=None):
     """
 
     Parameters
@@ -479,9 +480,16 @@ def RX_MPI_init(rxparams, dftparams=None):
     return commRX, commEnsemble, comm
 
 
-class EmbarrassinglyParallelSampling:
+class ParallelMC(object):
     def __init__(
-        self, comm, MCalgo, model, configs, kTs=None, subdirs=True, write_node=True
+        self,
+        comm,
+        MCalgo: Type[MCAlgorithm],
+        model: Model,
+        configs,
+        kTs,
+        subdirs=True,
+        write_node=True,
     ):
         """
 
@@ -491,8 +499,91 @@ class EmbarrassinglyParallelSampling:
             MPI communicator
         MCalgo: object for MonteCarlo algorithm
             MonteCarlo algorithm
-        model: dft_latgas
-            DFT lattice gas mapping  model
+        model: dft_latgas object
+            DFT lattice gas mapping model
+        configs: config object
+            Configurations
+        kTs: list
+            Temperature list
+        subdirs: boolean
+            if true,  working directory for this rank is made
+        """
+        self.comm = comm
+        self.rank = self.comm.Get_rank()
+        self.procs = self.comm.Get_size()
+        self.kTs = kTs
+        self.model = model
+        self.subdirs = subdirs
+        self.nreplicas = len(configs)
+        self.write_node = write_node
+
+        if not (self.procs == self.nreplicas == len(self.kTs)):
+            if self.rank == 0:
+                print(
+                    "ERROR: You have to set the number of replicas equal to the"
+                    + "number of temperatures equal to the number of processes"
+                )
+            sys.exit(1)
+
+        myconfig = configs[self.rank]
+        mytemp = kTs[self.rank]
+        self.mycalc = MCalgo(model, mytemp, myconfig)
+
+    def run(self, nsteps, sample_frequency, observer=ObserverBase()):
+        """
+
+        Parameters
+        ----------
+        nsteps: int
+            Number of Monte Carlo steps for running.
+        sample_frequency: int
+            Number of Monte Carlo steps for running.
+        observer: observer object
+
+        Returns
+        -------
+        obs_buffer: numpy array
+            Observables
+        """
+        if self.subdirs:
+            # make working directory for this rank
+            try:
+                os.mkdir(str(self.rank))
+            except FileExistsError:
+                pass
+            os.chdir(str(self.rank))
+        observables = self.mycalc.run(nsteps, sample_frequency, observer)
+        if self.write_node:
+            pickle_dump(self.mycalc.config, "config.pickle")
+        if self.subdirs:
+            os.chdir("../")
+        if sample_frequency:
+            obs_buffer = np.empty([self.procs, len(observables)])
+            self.comm.Allgather(observables, obs_buffer)
+            return obs_buffer
+
+
+class EmbarrassinglyParallelSampling:
+    def __init__(
+        self,
+        comm,
+        MCalgo: Type[MCAlgorithm],
+        model: Model,
+        configs,
+        kTs=None,
+        subdirs=True,
+        write_node=True,
+    ):
+        """
+
+        Parameters
+        ----------
+        comm: comm world
+            MPI communicator
+        MCalgo: Type[MCAlgorithm]
+            MonteCarlo algorithm class (not instance)
+        model: Model
+            Model
         configs: config object
             Configuration
         kTs: list
@@ -636,86 +727,10 @@ class EmbarrassinglyParallelSampling:
             obs /= nsample
             self.comm.Allreduce(obs, obs_buffer, op=MPI.SUM)
             obs_list = []
-            args_info = observer.obs_info(self.mycalc)
+            obs_info = observer.obs_info(self.mycalc)
             for i in range(len(self.kTs)):
-                obs_list.append(obs_decode(args_info, obs_buffer[i]))
+                obs_list.append(obs_info.decode(obs_buffer[i]))
             return obs_list
-
-
-class ParallelMC(object):
-    def __init__(
-        self, comm, MCalgo, model, configs, kTs, subdirs=True, write_node=True
-    ):
-        """
-
-        Parameters
-        ----------
-        comm: comm world
-            MPI communicator
-        MCalgo: object for MonteCarlo algorithm
-            MonteCarlo algorithm
-        model: dft_latgas object
-            DFT lattice gas mapping model
-        configs: config object
-            Configurations
-        kTs: list
-            Temperature list
-        subdirs: boolean
-            if true,  working directory for this rank is made
-        """
-        self.comm = comm
-        self.rank = self.comm.Get_rank()
-        self.procs = self.comm.Get_size()
-        self.kTs = kTs
-        self.model = model
-        self.subdirs = subdirs
-        self.nreplicas = len(configs)
-        self.write_node = write_node
-
-        if not (self.procs == self.nreplicas == len(self.kTs)):
-            if self.rank == 0:
-                print(
-                    "ERROR: You have to set the number of replicas equal to the"
-                    + "number of temperatures equal to the number of processes"
-                )
-            sys.exit(1)
-
-        myconfig = configs[self.rank]
-        mytemp = kTs[self.rank]
-        self.mycalc = MCalgo(model, mytemp, myconfig)
-
-    def run(self, nsteps, sample_frequency, observer=ObserverBase()):
-        """
-
-        Parameters
-        ----------
-        nsteps: int
-            Number of Monte Carlo steps for running.
-        sample_frequency: int
-            Number of Monte Carlo steps for running.
-        observer: observer object
-
-        Returns
-        -------
-        obs_buffer: numpy array
-            Observables
-        """
-        if self.subdirs:
-            # make working directory for this rank
-            try:
-                os.mkdir(str(self.rank))
-            except FileExistsError:
-                pass
-            os.chdir(str(self.rank))
-        observables = self.mycalc.run(nsteps, sample_frequency, observer)
-        if self.write_node:
-            pickle_dump(self.mycalc.config, "config.pickle")
-        if self.subdirs:
-            os.chdir("../")
-        if sample_frequency:
-            obs_buffer = np.empty([self.procs, len(observables)])
-            self.comm.Allgather(observables, obs_buffer)
-            return obs_buffer
 
 
 class RandomSampling_MPI(ParallelMC):
@@ -984,9 +999,9 @@ class TemperatureRX_MPI(ParallelMC):
             obs /= nsample
             self.comm.Allreduce(obs, obs_buffer, op=MPI.SUM)
             obs_list = []
-            args_info = observer.obs_info(self.mycalc)
+            obs_info = observer.obs_info(self.mycalc)
             for i in range(len(self.kTs)):
-                obs_list.append(obs_decode(args_info, obs_buffer[i]))
+                obs_list.append(obs_info.decode(obs_buffer[i]))
             if subdirs:
                 os.chdir("../")
             return obs_list

--- a/abics/scripts/activelearn.py
+++ b/abics/scripts/activelearn.py
@@ -44,8 +44,8 @@ from abics.applications.latgas_abinitio_interface.defect import (
     DFTConfigParams,
 )
 from abics.applications.latgas_abinitio_interface.run_base_mpi import (
-    runner,
-    runner_multistep,
+    Runner,
+    RunnerMultistep,
 )
 from abics.applications.latgas_abinitio_interface.vasp import VASPSolver
 from abics.applications.latgas_abinitio_interface.qe import QESolver

--- a/abics/scripts/activelearn.py
+++ b/abics/scripts/activelearn.py
@@ -23,6 +23,8 @@ import datetime
 
 import numpy as np
 
+from abics import __version__
+
 from abics.mc import RandomSampling
 
 from abics.mc_mpi import (
@@ -31,9 +33,9 @@ from abics.mc_mpi import (
     EmbarrassinglyParallelSampling,
 )
 from abics.applications.latgas_abinitio_interface import map2perflat
-from abics.applications.latgas_abinitio_interface import default_observer
+from abics.applications.latgas_abinitio_interface import DefaultObserver
 from abics.applications.latgas_abinitio_interface.model_setup import (
-    dft_latgas,
+    DFTLatticeGas,
     ObserverParams,
     perturb_structure,
 )
@@ -47,7 +49,7 @@ from abics.applications.latgas_abinitio_interface.run_base_mpi import (
 )
 from abics.applications.latgas_abinitio_interface.vasp import VASPSolver
 from abics.applications.latgas_abinitio_interface.qe import QESolver
-from abics.applications.latgas_abinitio_interface.aenet import aenetSolver
+from abics.applications.latgas_abinitio_interface.aenet import AenetSolver
 from abics.applications.latgas_abinitio_interface.openmx import OpenMXSolver
 from abics.applications.latgas_abinitio_interface.mocksolver import MockSolver
 from abics.applications.latgas_abinitio_interface.params import ALParams
@@ -73,7 +75,7 @@ def main_impl(tomlfile):
         parallel_level = alparams.properties.get("parallel_level", {})
         solver = QESolver(alparams.path, parallel_level=parallel_level)
     elif alparams.solver == "aenet":
-        solver = aenetSolver(
+        solver = AenetSolver(
             alparams.path, alparams.ignore_species, alparams.solver_run_scheme
         )
     elif alparams.solver == "openmx":
@@ -480,7 +482,7 @@ def main_impl(tomlfile):
 def main():
     now = datetime.datetime.now()
     if MPI.COMM_WORLD.Get_rank() == 0:
-        print("Running abics_mlref (abICS v.2.0.0) on {}".format(now))
+        print(f"Running abics_mlref (abICS v{__version__}) on {now}")
 
     tomlfile = sys.argv[1] if len(sys.argv) > 1 else "input.toml"
     if MPI.COMM_WORLD.Get_rank() == 0:

--- a/abics/scripts/activelearn_spawn.py
+++ b/abics/scripts/activelearn_spawn.py
@@ -28,9 +28,9 @@ from abics.mc_mpi import (
     EmbarrassinglyParallelSampling,
 )
 from abics.applications.latgas_abinitio_interface import map2perflat
-from abics.applications.latgas_abinitio_interface import default_observer
+from abics.applications.latgas_abinitio_interface import DefaultObserver
 from abics.applications.latgas_abinitio_interface.model_setup import (
-    dft_latgas,
+    DFTLatticeGas,
     ObserverParams,
 )
 from abics.applications.latgas_abinitio_interface.defect import (
@@ -43,7 +43,7 @@ from abics.applications.latgas_abinitio_interface.run_base_mpi import (
 )
 from abics.applications.latgas_abinitio_interface.vasp import VASPSolver
 from abics.applications.latgas_abinitio_interface.qe import QESolver
-from abics.applications.latgas_abinitio_interface.aenet import aenetSolver
+from abics.applications.latgas_abinitio_interface.aenet import AenetSolver
 from abics.applications.latgas_abinitio_interface.openmx import OpenMXSolver
 from abics.applications.latgas_abinitio_interface.mocksolver import MockSolver
 from abics.applications.latgas_abinitio_interface.params import ALParams
@@ -67,7 +67,7 @@ def main_impl(tomlfile):
         parallel_level = alparams.properties.get("parallel_level", {})
         solver = QESolver(alparams.path, parallel_level=parallel_level)
     elif alparams.solver == "aenet":
-        solver = aenetSolver(
+        solver = AenetSolver(
             alparams.path, alparams.ignore_species, alparams.solver_run_scheme
         )
     elif alparams.solver == "openmx":
@@ -115,7 +115,7 @@ def main_impl(tomlfile):
                 "It seems you've already run the first active learning step. You should train now."
             )
             sys.exit(1)
-        model = dft_latgas(energy_calculator, save_history=False)
+        model = DFTLatticeGas(energy_calculator, save_history=False)
         configparams = DFTConfigParams.from_toml(tomlfile)
         config = defect_config(configparams)
         configs = [config] * nreplicas
@@ -139,7 +139,7 @@ def main_impl(tomlfile):
                 nsteps=nsteps // sample_frequency,
                 sample_frequency=1,
                 print_frequency=1,
-                observer=default_observer(comm, False),
+                observer=Observer(comm, False),
                 subdirs=True,
             )
 

--- a/abics/scripts/activelearn_spawn.py
+++ b/abics/scripts/activelearn_spawn.py
@@ -38,8 +38,8 @@ from abics.applications.latgas_abinitio_interface.defect import (
     DFTConfigParams,
 )
 from abics.applications.latgas_abinitio_interface.run_base_mpi import (
-    runner,
-    runner_multistep,
+    Runner,
+    RunnerMultistep,
 )
 from abics.applications.latgas_abinitio_interface.vasp import VASPSolver
 from abics.applications.latgas_abinitio_interface.qe import QESolver
@@ -82,7 +82,7 @@ def main_impl(tomlfile):
     # we first choose a "model" defining how to perform energy calculations and trial steps
     # on the "configuration" defined below
     if len(alparams.base_input_dir) == 1:
-        energy_calculator = runner(
+        energy_calculator = Runner(
             base_input_dir=alparams.base_input_dir[0],
             Solver=solver,
             nprocs_per_solver=nprocs_per_replica,
@@ -91,10 +91,10 @@ def main_impl(tomlfile):
             solver_run_scheme=alparams.solver_run_scheme,
         )
     else:
-        energy_calculator = runner_multistep(
+        energy_calculator = RunnerMultistep(
             base_input_dirs=alparams.base_input_dir,
             Solver=solver,
-            runner=runner,
+            runner=Runner,
             nprocs_per_solver=nprocs_per_replica,
             comm=MPI.COMM_SELF,
             perturb=alparams.perturb,

--- a/abics/scripts/main.py
+++ b/abics/scripts/main.py
@@ -46,9 +46,9 @@ from abics.applications.latgas_abinitio_interface.defect import (
     DFTConfigParams,
 )
 from abics.applications.latgas_abinitio_interface.run_base_mpi import (
-    runner,
-    runner_ensemble,
-    runner_multistep,
+    Runner,
+    RunnerEnsemble,
+    RunnerMultistep,
 )
 from abics.applications.latgas_abinitio_interface.vasp import VASPSolver
 from abics.applications.latgas_abinitio_interface.qe import QESolver
@@ -163,10 +163,10 @@ def main_impl(tomlfile):
                 "You must specify more than one base_input_dir for ensemble calculator"
             )
             sys.exit(1)
-        energy_calculator = runner_ensemble(
+        energy_calculator = RunnerEnsemble(
             base_input_dirs=dftparams.base_input_dir,
             Solver=solver,
-            runner=runner,
+            runner=Runner,
             nprocs_per_solver=nprocs_per_replica,
             comm=commEnsemble,
             perturb=dftparams.perturb,
@@ -175,7 +175,7 @@ def main_impl(tomlfile):
         )
     else:
         if len(dftparams.base_input_dir) == 1:
-            energy_calculator = runner(
+            energy_calculator = Runner(
                 base_input_dir=dftparams.base_input_dir[0],
                 Solver=solver,
                 nprocs_per_solver=nprocs_per_replica,
@@ -185,10 +185,10 @@ def main_impl(tomlfile):
                 use_tmpdir=dftparams.use_tmpdir,
             )
         else:
-            energy_calculator = runner_multistep(
+            energy_calculator = RunnerMultistep(
                 base_input_dirs=dftparams.base_input_dir,
                 Solver=solver,
-                runner=runner,
+                runner=Runner,
                 nprocs_per_solver=nprocs_per_replica,
                 comm=MPI.COMM_SELF,
                 perturb=dftparams.perturb,
@@ -243,7 +243,7 @@ def main_impl(tomlfile):
             sys.exit(1)
 
         energy_calculators = [
-            runner(
+            Runner(
                 base_input_dir=base_input_dir,
                 Solver=copy.deepcopy(solver),
                 nprocs_per_solver=nprocs_per_replica,

--- a/abics/scripts/train.py
+++ b/abics/scripts/train.py
@@ -16,6 +16,15 @@
 
 import sys, datetime
 
+import os, sys
+import threading
+import itertools
+
+import numpy as np
+import networkx as nx
+from pymatgen.core import Structure
+
+from abics import __version__
 from abics.applications.latgas_abinitio_interface.params import DFTParams, TrainerParams
 from abics.applications.latgas_abinitio_interface import aenet_trainer
 from abics.applications.latgas_abinitio_interface import map2perflat
@@ -25,12 +34,6 @@ from abics.applications.latgas_abinitio_interface.defect import (
     DFTConfigParams,
 )
 
-from pymatgen.core import Structure
-import numpy as np
-import os, sys
-import threading
-import networkx as nx
-import itertools
 
 
 def main_impl(tomlfile):
@@ -234,7 +237,7 @@ def main_impl(tomlfile):
 
 def main():
     now = datetime.datetime.now()
-    print("Running abics_train (abICS v.2.0.0) on {}".format(now))
+    print(f"Running abics_train (abICS v{__version__}) on {now}")
     tomlfile = sys.argv[1] if len(sys.argv) > 1 else "input.toml"
     print("-Reading input from: {}".format(tomlfile))
     main_impl(tomlfile)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ abicsRXsepT = "abics.scripts.abicsRXsepT:main"
 abics_mlref = "abics.scripts.activelearn:main"
 abics_train = "abics.scripts.train:main"
 
+[tool.mypy]
+files = "abics"
+ignore_missing_imports = true
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/test/openmx/test_openmx_io.py
+++ b/test/openmx/test_openmx_io.py
@@ -46,10 +46,10 @@ if __name__ == '__main__':
     phys.structure.add_site_property("seldyn", [[False, False, False]] * len(phys.structure.sites))
     input.update_info_by_structure(phys.structure)
     # test subprocess mode and seldyn
-    from abics.applications.latgas_abinitio_interface.run_base_mpi import runner
+    from abics.applications.latgas_abinitio_interface.run_base_mpi import Runner
     from mpi4py import MPI
     nprocs_per_replica = 1
-    energy_calculator = runner(
+    energy_calculator = Runner(
         base_input_dir=base_dir,
         Solver=solver,
         nprocs_per_solver=nprocs_per_replica,

--- a/tests/integration/active_learn/install_aenet.sh
+++ b/tests/integration/active_learn/install_aenet.sh
@@ -10,6 +10,8 @@
 #   ln -s `which gcc-11` ./gcc
 #   PATH=`pwd`:$PATH sh ./install_aenet.sh
 
+set -ue
+
 VERSION=2.0.4
 
 URL=https://github.com/atomisticnet/aenet/archive/refs/tags/v${VERSION}.tar.gz

--- a/tests/test_aenet.py
+++ b/tests/test_aenet.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from pymatgen.core import Structure
 
-from abics.applications.latgas_abinitio_interface.aenet import aenetSolver
+from abics.applications.latgas_abinitio_interface.aenet import AenetSolver
 
 
 class TestAENET(unittest.TestCase):
@@ -35,7 +35,7 @@ class TestAENET(unittest.TestCase):
         os.makedirs(workdir)
 
     def setUp(self):
-        self.solver = aenetSolver(".")
+        self.solver = AenetSolver(".")
         self.rootdir = os.path.dirname(__file__)
         self.datadir = os.path.join(self.rootdir, "data", "aenet")
         self.workdir = os.path.join(self.rootdir, "res", "aenet")

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -23,7 +23,7 @@ from numpy.linalg import inv
 from pymatgen.core import Structure
 
 from abics.mc_mpi import RXParams
-from abics.applications.latgas_abinitio_interface.model_setup import group, perturb_structure
+from abics.applications.latgas_abinitio_interface.model_setup import Group, perturb_structure
 from abics.applications.latgas_abinitio_interface.defect import (
     defect_config,
     DFTConfigParams,
@@ -99,8 +99,8 @@ class TestInput(unittest.TestCase):
         self.assertEqual(spinel_config.base_structure.sites[0].coords[2], 0.0)
 
         gs = [
-            group("Al", ["Al"], coords=[[[0.0, 0.0, 0.0]]]),
-            group("OH", ["O", "H"], coords=[[[0.0, 0.0, 0.0], [0.1, 0.1, 0.1]]]),
+            Group("Al", ["Al"], coords=[[[0.0, 0.0, 0.0]]]),
+            Group("OH", ["O", "H"], coords=[[[0.0, 0.0, 0.0], [0.1, 0.1, 0.1]]]),
         ]
 
         for i in range(2):

--- a/tests/test_mc.py
+++ b/tests/test_mc.py
@@ -20,13 +20,13 @@ import numpy as np
 import numpy.random as random
 
 
-from abics.mc import model, CanonicalMonteCarlo
+from abics.mc import Model, CanonicalMonteCarlo
 
 random.seed(12345)
 
 
 class TestMC(unittest.TestCase):
-    class model(model):
+    class MyModel(Model):
         def energy(self, config):
             return config[0] * config[1]
 
@@ -41,7 +41,7 @@ class TestMC(unittest.TestCase):
             return dconfig, dE
 
     def test_mc(self):
-        self.mc = CanonicalMonteCarlo(TestMC.model(), 1.0, [1.0,1.0])
+        self.mc = CanonicalMonteCarlo(TestMC.MyModel(), 1.0, [1.0,1.0])
         # self.mc = CanonicalMonteCarlo(TestMC.dmodel, 1.0, 1)
         N = 100
         S = 0.0


### PR DESCRIPTION
Two types of name conventions of classes appear: `snake_case` and `CamelCase`.
This PR chooses `CamelCase` because PEP8 recommends it.
While abICS v2, we also offer the old names as aliases for the backward compatibility.

- `abics.mc`
    - `model` -> `Model`
    - `observer_base` -> `ObserverBase`
    - `grid_1D` -> `Grid1D`
- `abics.applications.latgas_abinitio_interface.default_observer`
    - `default_observer` -> `DefaultObserver`
    - `ensemble_error_observer` -> `EnsembleErrorObserver`
- `abics.applications.latgas_abinitio_interface.model_setup`
    - `dft_latgas` -> `DFTLatticeGas`
    - `energy_lst` -> `EnergyList`
    - `group` -> `Group`
    - `defect_sublattice` -> `DefectSublattice`
    - `config` -> `Config`
- `abics.applications.latgas_abinitio_interface.run_base_mpi`
    - `runner` -> `Runner`
    - `runner_multistep` -> `RunnerMultistep`
    - `runner_ensemble` -> `RunnerEnsemble`
    - `run_mpispawn` -> `RunMpispawn`
    - `run_mpispawn_ready` -> `RunMpispawnReady`
    - `run_mpispawn_wrapper` -> `RunMpispawnWrapper`
    - `run_subprocess` -> `RunSubprocess`
    - `run_function` -> `RunFunction`