### PR TITLE
fix config.defect_structure.groups.coords in st2abics

### DIFF
--- a/abics/scripts/st2abics_config.py
+++ b/abics/scripts/st2abics_config.py
@@ -145,12 +145,12 @@ def main():
             for coord in group["coords"]:
                 if len(coord) == 1:
                     c = coord[0]
-                    config.append('"{} {} {}"'.format(c[0], c[1], c[2]))
+                    config.append('[[{}, {}, {}]]'.format(c[0], c[1], c[2]))
                 else:
-                    config.append('"""')
+                    config.append('[')
                     for c in coord:
-                        config.append("{} {} {}".format(c[0], c[1], c[2]))
-                    config.append('""",')
+                        config.append("[{}, {}, {}],".format(c[0], c[1], c[2]))
+                    config.append('],')
             config.append("]")
             config.append("num = {}".format(group["num"]))
             config.append("")


### PR DESCRIPTION
This was necessary to make st2abics compatible with the current implementation of our toml reader.