### PR TITLE
Update version constraints of dependencies

### DIFF
--- a/.github/workflows/Test_abICS.yml
+++ b/.github/workflows/Test_abICS.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.9', '3.12']
+        python-version: ['3.9', '3.13']
+        numpy-version: ['1.20.0', '1.26.4', 'latest']
         testname: [Unit, Sampling, ActiveLearnAenet, ActiveLearnNequip, ActiveLearnMLIP-3]
       fail-fast: false
 
@@ -31,6 +32,11 @@ jobs:
         sudo apt update
         sudo apt install -y libopenmpi-dev openmpi-bin parallel
         sudo apt install -y python3-mpi4py
+        if [ "${{ matrix.numpy-version }}" = "latest" ]; then
+          python -m pip install numpy
+        else
+          python -m pip install numpy==${{ matrix.numpy-version }}
+        fi
         python -m pip install Cython
     - name: Install abICS
       run: python -m pip install .
@@ -46,13 +52,13 @@ jobs:
                    sh ./run.sh
                    ;;
         ActiveLearnAenet ) cd tests/integration/active_learn_aenet
-                            sh ./install_aenet.sh
-                            sh ./run.sh ;;
+                           sh ./install_aenet.sh
+                           sh ./run.sh ;;
         ActiveLearnNequip ) cd tests/integration/active_learn_nequip
-                             sh ./install_nequip.sh
-                             sh ./run.sh ;;
+                            sh ./install_nequip.sh
+                            sh ./run.sh ;;
         ActiveLearnMLIP-3 ) cd tests/integration/active_learn_mlip3
-                             sh ./install_mlip3.sh
-                             sh ./run.sh ;;
+                            sh ./install_mlip3.sh
+                            sh ./run.sh ;;
         * ) echo "Unknown testname";;
         esac

--- a/.github/workflows/Test_abICS.yml
+++ b/.github/workflows/Test_abICS.yml
@@ -17,6 +17,9 @@ jobs:
         python-version: ['3.9', '3.13']
         numpy-version: ['1.20.0', '1.26.4', 'latest']
         testname: [Unit, Sampling, ActiveLearnAenet, ActiveLearnNequip, ActiveLearnMLIP-3]
+        exclude:
+          - python-version: '3.13'
+            numpy-version: '1.20.0'
       fail-fast: false
 
     steps:

--- a/abics/scripts/main_potts.py
+++ b/abics/scripts/main_potts.py
@@ -39,7 +39,7 @@ def main_potts(params_root: MutableMapping):
     param_config = params_root["config"]
     Q = param_config.get("Q", 2)
     Ls = param_config["L"]
-    nspins = typing.cast(int, np.product(Ls))
+    nspins = typing.cast(int, np.prod(Ls))
     write_node = True
 
     model = Potts()

--- a/docs/sphinx/en/source/tutorial/other_models.rst
+++ b/docs/sphinx/en/source/tutorial/other_models.rst
@@ -15,13 +15,14 @@ Installation of NequIP
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To use ``nequip``, you need to install NequIP.
+Currently, NequIP 0.6.2 is supported.
 
 Install it with the following command.
 
 .. code-block:: bash
 
     $ python3 -m pip install wandb
-    $ python3 -m pip install nequip
+    $ python3 -m pip install nequip==0.6.2
 
 Also, when installing abICS, you can install NequIP by specifying the [nequip] option.
 
@@ -130,21 +131,21 @@ Installation of Allegro
 
 Install Allegro with the following command.
 
+Currently, nequip-allegro 0.3.0 is supported.
+
 .. code-block:: bash
 
-    $ git clone --depth 1 https://github.com/mir-group/allegro.git
-    $ cd allegro
-    $ python3 -m pip install .
+   $ python3 -m pip install nequip-allegro==0.3.0
 
 
 Preparation of input files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-First, prepare input_allegro.toml and set the parameters required to run Allegro.   
+First, prepare input_allegro.toml and set the parameters required to run Allegro.
 Below, we extract ``[sampling.solver]`` and ``[train]`` with changes from the aenet input.
 
 .. code-block:: toml
-   
+
    [sampling.solver]
    type = 'allegro'
    base_input_dir = './baseinput_allegro'
@@ -280,12 +281,12 @@ Also, create the MLIP-3 input file ``input.almtp`` in the ``mlip_3_train_input/t
    version = 1.1.0
    potential_name = MTP1m
    species_count = 3
-   potential_tag = 
+   potential_tag =
    radial_basis_type = RBChebyshev
-    min_dist = 2.3
-   	max_dist = 5
-   	radial_basis_size = 8
-	radial_funcs_count = 2
+   min_dist = 2.3
+      max_dist = 5
+      radial_basis_size = 8
+   radial_funcs_count = 2
    alpha_moments_count = 8
    alpha_index_basic_count = 5
    alpha_index_basic = {{0, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {1, 0, 0, 0}}

--- a/docs/sphinx/ja/source/tutorial/other_models.rst
+++ b/docs/sphinx/ja/source/tutorial/other_models.rst
@@ -15,29 +15,30 @@ NequIP のインストール
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``nequip`` の利用には、 NequIPのインストールが必要です。
+2025年6月現在、NequIP 0.6.2 がサポートされています。
 
 下記コマンドにてインストールします。
 
 .. code-block:: bash
 
-    $ python3 -m pip install wandb
-    $ python3 -m pip install nequip
+   $ python3 -m pip install wandb
+   $ python3 -m pip install nequip==0.6.2
 
-また、abICSインストール時に[nequip]オプションを指定すれば、NequIPもインストールされます。
+また、abICSインストール時に ``[nequip]`` オプションを指定すれば、NequIPもインストールされます。
 
 .. code-block:: bash
 
-    $ cd /path/to/abics
-    $ python3 -m pip install '.abics[nequip]'
+   $ cd /path/to/abics
+   $ python3 -m pip install '.abics[nequip]'
 
 インプットファイルの準備
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 まず、input_nequip.tomlを準備し、NequIPの実行に必要なパラメータを設定します。
-下では、aenetのインプットから変更のある[sampling.solver]と[train]を抜粋しています。
+下では、aenetのインプットから変更のある ``[sampling.solver]`` と ``[train]`` を抜粋しています。
 
 .. code-block:: toml
-    
+
    [sampling.solver]
    type = 'nequip'
    base_input_dir = './baseinput_nequip'
@@ -129,21 +130,21 @@ Allegro のインストール
 
 下記コマンドにてインストールします。
 
+2025年6月現在、nequip-allegro 0.3.0 がサポートされています。
+
 .. code-block:: bash
 
-    $ git clone --depth 1 https://github.com/mir-group/allegro.git
-    $ cd allegro
-    $ python3 -m pip install .
+   $ python3 -m pip install nequip-allegro==0.3.0
 
 
 インプットファイルの準備
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 まず、input_allegro.tomlを準備し、Allegroの実行に必要なパラメータを設定します。
-下では、aenetのインプットから変更のある[sampling.solver]と[train]を抜粋しています。
+下では、aenetのインプットから変更のある ``[sampling.solver]`` と ``[train]`` を抜粋しています。
 
 .. code-block:: toml
-    
+
    [sampling.solver]
    type = 'allegro'
    base_input_dir = './baseinput_allegro'
@@ -237,20 +238,20 @@ MLIP-3 のインストール
 
 .. code-block:: bash
 
-    $ git clone https://gitlab.com/ashapeev/mlip-3.git
-    $ cd mlip-3
-    $ ./configure --no-mpi
-    $ make mlp
+   $ git clone https://gitlab.com/ashapeev/mlip-3.git
+   $ cd mlip-3
+   $ ./configure --no-mpi
+   $ make mlp
 
 
 インプットファイルの準備
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 まず、input_mlip3.tomlを準備し、mlip-3の実行に必要なパラメータを設定します。
-下では、aenetのインプットから変更のある[sampling.solver]と[train]を抜粋しています。
+下では、aenetのインプットから変更のある ``[sampling.solver]`` と ``[train]`` を抜粋しています。
 
 .. code-block:: toml
-    
+
    [sampling.solver]
    type = 'mlip_3'
    path= '~/git/mlip-3/bin/mlp'
@@ -278,12 +279,12 @@ MLIP-3の実行ファイル ``mlp`` のパスを指定します。お使いの�
    version = 1.1.0
    potential_name = MTP1m
    species_count = 3
-   potential_tag = 
+   potential_tag =
    radial_basis_type = RBChebyshev
-    min_dist = 2.3
-   	max_dist = 5
-   	radial_basis_size = 8
-	radial_funcs_count = 2
+      min_dist = 2.3
+      max_dist = 5
+      radial_basis_size = 8
+   radial_funcs_count = 2
    alpha_moments_count = 8
    alpha_index_basic_count = 5
    alpha_index_basic = {{0, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}, {1, 0, 0, 0}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ scipy = "^1"
 mpi4py = "^3"
 pymatgen = ">=2022.1.20"
 qe_tools = "^1.1"
-nequip = {version=">=0.5.6", optional=true}
+nequip = {version=">=0.5.6, <0.7", optional=true}
 
 [tool.poetry.extras]
 nequip = ["nequip"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ python = "^3.9"
 numpy = ">=1.20"
 toml = ">=0.10"
 scipy = "^1"
-mpi4py = "^3"
+mpi4py = ">=3"
 pymatgen = ">=2022.1.20"
 qe_tools = "^1.1"
 nequip = {version=">=0.5.6, <0.7", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-numpy = "^1.20"
+numpy = ">=1.20"
 toml = ">=0.10"
 scipy = "^1"
 mpi4py = "^3"

--- a/tests/integration/active_learn_nequip/install_nequip.sh
+++ b/tests/integration/active_learn_nequip/install_nequip.sh
@@ -11,5 +11,5 @@ which python3
 echo
 
 python3 -m pip install torch==2.5.1
-python3 -m pip install 'nequip<0.7'
-python3 -m pip install git+https://github.com/mir-group/allegro.git
+python3 -m pip install nequip==0.6.2
+python3 -m pip install nequip-allegro==0.3.0

--- a/tests/integration/active_learn_nequip/install_nequip.sh
+++ b/tests/integration/active_learn_nequip/install_nequip.sh
@@ -11,5 +11,5 @@ which python3
 echo
 
 python3 -m pip install torch==2.5.1
-python3 -m pip install nequip
+python3 -m pip install 'nequip<0.7'
 python3 -m pip install git+https://github.com/mir-group/allegro.git


### PR DESCRIPTION
- Nequip 0.7.0 / Allegro 0.4.0 broke the backward compatibility
    - In the test and the tutorial, use Nequip 0.6.2 and Allegro 0.3.0 explicitly
- Numpy 2 becomes available (`^1.20` => `>=1.20`)
- Mpi4Py 4.x becomes available (`^3` => `>=3`)