### PR TITLE
Fix Python 3.13 test failures (RXMC NumPy 2 bug; document/skip NequIP)

### DIFF
--- a/.github/workflows/Test_abICS.yml
+++ b/.github/workflows/Test_abICS.yml
@@ -21,6 +21,18 @@ jobs:
         exclude:
           - python-version: '3.13'
             numpy-version: '1.20.0'
+          # nequip 0.6.2 (the pinned version) calls the removed numpy.in1d and
+          # therefore requires numpy<2, but Python 3.13 has no numpy 1.x wheels.
+          # This is an upstream nequip/numpy-2 incompatibility, not an abICS bug,
+          # so skip the nequip integration test on Python 3.13.
+          #
+          # NOTE for developers: as a result the nequip path is only exercised on
+          # Python 3.9 (install_nequip.sh pins numpy<2 for that environment); there
+          # is no numpy-2 / Python 3.13 coverage for nequip. Restoring it requires
+          # migrating the abICS nequip solver/trainer to nequip >=0.7 (a backwards-
+          # incompatible rewrite). See the nequip cap in pyproject.toml.
+          - python-version: '3.13'
+            testname: ActiveLearnNequip
       fail-fast: false
 
     steps:

--- a/abics/sampling/rxmc.py
+++ b/abics/sampling/rxmc.py
@@ -203,10 +203,14 @@ class TemperatureRX_MPI(ParallelMC):
         procrank: int
         """
         i = np.argwhere(self.rank_to_T == Trank)
-        if i is None:
+        if i.size == 0:
             sys.exit("Internal error in TemperatureRX_MPI.find_procrank_from_Trank")
         else:
-            return i
+            # np.argwhere returns a 2-D array (shape (1, 1) here); return a plain
+            # Python int so it can be used as an MPI source/dest rank. NumPy 2.x
+            # rejects int() on non-0-dimensional arrays, which previously broke
+            # comm.Recv/Send on Python 3.13 (numpy>=2).
+            return int(i[0, 0])
 
     def Xtrial(self, XCscheme):
         """

--- a/docs/sphinx/en/source/tutorial/other_models.rst
+++ b/docs/sphinx/en/source/tutorial/other_models.rst
@@ -17,12 +17,20 @@ Installation of NequIP
 To use ``nequip``, you need to install NequIP.
 Currently, NequIP 0.6.2 is supported.
 
+.. note::
+
+   The supported NequIP (< 0.7) relies on ``numpy.in1d``, which was removed in
+   NumPy 2, so it requires a ``numpy<2`` environment. Because no NumPy 1.x wheels
+   are available for Python 3.13, the NequIP path currently cannot be used on
+   Python 3.13 (please use Python 3.12 or earlier).
+
 Install it with the following command.
 
 .. code-block:: bash
 
     $ python3 -m pip install wandb
     $ python3 -m pip install nequip==0.6.2
+    $ python3 -m pip install "numpy<2"
 
 Also, when installing abICS, you can install NequIP by specifying the [nequip] option.
 
@@ -30,6 +38,11 @@ Also, when installing abICS, you can install NequIP by specifying the [nequip] o
 
     $ cd /path/to/abics
     $ python3 -m pip install '.[nequip]'
+    $ python3 -m pip install "numpy<2"
+
+The ``numpy<2`` constraint above is required regardless of the installation
+method (the ``[nequip]`` option does not constrain the numpy version, so install
+it separately).
 
 Preparation of input files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -136,7 +149,12 @@ Currently, nequip-allegro 0.3.0 is supported.
 .. code-block:: bash
 
    $ python3 -m pip install nequip-allegro==0.3.0
+   $ python3 -m pip install "numpy<2"
 
+.. note::
+
+   Allegro runs on top of the same NequIP (< 0.7) stack, so like NequIP it
+   requires a ``numpy<2`` environment and cannot be used on Python 3.13.
 
 Preparation of input files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/sphinx/ja/source/tutorial/other_models.rst
+++ b/docs/sphinx/ja/source/tutorial/other_models.rst
@@ -17,19 +17,31 @@ NequIP のインストール
 ``nequip`` の利用には、 NequIPのインストールが必要です。
 2025年6月現在、NequIP 0.6.2 がサポートされています。
 
+.. note::
+
+   サポートされている NequIP (< 0.7) は、NumPy 2 で削除された ``numpy.in1d``
+   を利用するため、 ``numpy<2`` の環境が必要です。Python 3.13 には NumPy 1.x の
+   wheel が存在しないため、現状 NequIP 経路は Python 3.13 では利用できません
+   (Python 3.12 以前をご利用ください)。
+
 下記コマンドにてインストールします。
 
 .. code-block:: bash
 
    $ python3 -m pip install wandb
    $ python3 -m pip install nequip==0.6.2
+   $ python3 -m pip install "numpy<2"
 
 また、abICSインストール時に ``[nequip]`` オプションを指定すれば、NequIPもインストールされます。
 
 .. code-block:: bash
 
    $ cd /path/to/abics
-   $ python3 -m pip install '.abics[nequip]'
+   $ python3 -m pip install '.[nequip]'
+   $ python3 -m pip install "numpy<2"
+
+いずれのインストール方法でも、上記の ``numpy<2`` 制約が必要です（``[nequip]``
+オプションは numpy のバージョンを制約しないため、別途指定してください）。
 
 インプットファイルの準備
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -135,7 +147,12 @@ Allegro のインストール
 .. code-block:: bash
 
    $ python3 -m pip install nequip-allegro==0.3.0
+   $ python3 -m pip install "numpy<2"
 
+.. note::
+
+   Allegro は上記の NequIP (< 0.7) スタック上で動作するため、NequIP と同じく
+   ``numpy<2`` の環境が必要で、Python 3.13 では利用できません。
 
 インプットファイルの準備
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ scipy = "^1"
 mpi4py = ">=3"
 pymatgen = ">=2022.1.20"
 qe_tools = "^1.1"
+# nequip is capped at <0.7: 0.7+ is a backwards-incompatible rewrite that the
+# abICS nequip solver/trainer do not yet support. The supported series uses the
+# removed numpy.in1d, so it needs numpy<2 and cannot run on Python 3.13.
 nequip = {version=">=0.5.6, <0.7", optional=true}
 
 [tool.poetry.extras]

--- a/tests/integration/active_learn_nequip/install_nequip.sh
+++ b/tests/integration/active_learn_nequip/install_nequip.sh
@@ -2,6 +2,13 @@
 
 # This script installs pytorch, nequip, and allegro
 # into python3 environment
+#
+# NOTE for developers:
+# nequip is pinned to 0.6.2 (and nequip-allegro to 0.3.0) because the abICS
+# nequip solver/trainer target the pre-0.7 API. That series uses numpy.in1d,
+# which was removed in NumPy 2, so this test only works with numpy<2 and is
+# therefore restricted to Python 3.9 in the CI matrix (Python 3.13 has no
+# numpy 1.x wheels). Lifting this requires migrating abICS to nequip >=0.7.
 
 set -ue
 
@@ -10,6 +17,14 @@ which python3
 
 echo
 
+# Pin numpy<2 up front: nequip 0.6.2 declares "numpy" with no upper bound but
+# uses numpy.in1d (removed in NumPy 2). Setting it before the nequip stack keeps
+# the subsequent installs resolving against a compatible numpy.
+python3 -m pip install "numpy<2"
+
 python3 -m pip install torch==2.5.1
 python3 -m pip install nequip==0.6.2
 python3 -m pip install nequip-allegro==0.3.0
+
+# Re-assert numpy<2 in case any of the above pulled in numpy>=2.
+python3 -m pip install "numpy<2"


### PR DESCRIPTION
## Overview

Make the test suite pass on Python 3.13. The `Test for abICS` workflow had been
auto-disabled by GitHub for inactivity; after re-enabling it, two pre-existing
Python 3.13 failures surfaced. Both are unrelated to the recent MLIP work; they
affect `develop` directly.

## 1. RXMC replica exchange crash under NumPy 2 (real bug — fixed)

`abics/sampling/rxmc.py::find_procrank_from_Trank` returned the raw
`np.argwhere(...)` result — a 2-D array of shape `(1, 1)` — which was then passed
as the MPI source/dest rank to `comm.Recv`/`comm.Send`. NumPy 2 rejects `int()`
on a non-0-dimensional array, raising

```
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

so any replica exchange crashed on Python 3.13 (numpy>=2). NumPy 1.x silently
allowed the size-1 conversion, which is why Python 3.9 passed.

Fix: return a plain `int(i[0, 0])`, and fix the dead `if i is None` guard
(`np.argwhere` never returns `None`) to `if i.size == 0`.

Reproduced and verified locally with Python 3.13 / numpy 2.4.6 / mpi4py 4.1.2:
the `mock`, `potts`, and `potts_pamc` sampling tests and the 31 unit tests pass.

## 2. NequIP cannot run on Python 3.13 (upstream limitation — documented & skipped)

The supported nequip series (`<0.7`, pinned in `pyproject.toml`) calls the
removed `numpy.in1d`, so it needs `numpy<2`. Python 3.13 has no numpy 1.x wheels,
so this path cannot run there. This is an upstream nequip/numpy-2 incompatibility,
not an abICS bug.

- Exclude `ActiveLearnNequip` from the Python 3.13 CI matrix (nequip is still
  tested on Python 3.9 with all numpy variants).
- Pin `numpy<2` in `install_nequip.sh` (before and after the nequip stack).
- Document the `numpy<2` / no-Python-3.13 requirement for both the NequIP and
  Allegro install paths (JA/EN), and explain the nequip `<0.7` cap in
  `pyproject.toml`, plus developer notes in the workflow and install script.

## Also

- Re-enable the `Test for abICS` workflow and add a `workflow_dispatch` trigger
  (it had been auto-disabled by GitHub).

## Follow-up

Restoring numpy-2 / Python 3.13 coverage for NequIP requires migrating the abICS
nequip solver/trainer to nequip `>=0.7` (a backwards-incompatible rewrite),
tracked separately.

## Review

Reviewed with Codex over three rounds; converged with no remaining blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
