### PR TITLE
Fix the docs deploy job by pushing with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -17,7 +17,9 @@ jobs:
       contents: write  # push the built docs to the gh-pages branch
     steps:
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4.x
+      # pinned to a commit: the job now carries a write-capable GITHUB_TOKEN,
+      # so a third-party action must not be resolved through a mutable tag
+      uses: rlespinasse/github-slug-action@797d68864753cbceedc271349d402da4590e6302  # v4.5.0
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -13,6 +13,8 @@ jobs:
   deploy:
     timeout-minutes: 10.0
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write  # push the built docs to the gh-pages branch
     steps:
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v4.x
@@ -51,13 +53,6 @@ jobs:
         cd ${GITHUB_WORKSPACE}/main/docs
         sh make.sh
 
-    - name: Deploy Configuration
-      run: |
-          mkdir ~/.ssh
-          ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-          echo "${{ secrets.GH_ACTIONS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
-          chmod 400 ~/.ssh/id_rsa
-
     - name: Push
       env:
         GIT_USER: "abICS Developers"
@@ -83,7 +78,6 @@ jobs:
           cd gh-pages
           git config --local user.name "${GIT_USER}"
           git config --local user.email "${GIT_EMAIL}"
-          git remote set-url origin git@github.com:${GITHUB_REPOSITORY}.git
           git add docs
           if git commit -m "Deploy docs to ${TARGET_NAME} by GitHub Actions triggered by ${GITHUB_SHA}"
           then


### PR DESCRIPTION
## Problem

The `deploy` workflow has failed on every run since 2026-06-16 (last success: 2025-12-13), so the published documentation has not been updated since then. Every run fails at the final push:

```
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
##[error]Process completed with exit code 128.
```

The workflow writes the `GH_ACTIONS_DEPLOY_KEY` secret to `~/.ssh/id_rsa` and pushes to `gh-pages` over SSH. The secret is still present, but the repository has no deploy keys registered any more, so the matching public key is gone and the push can never authenticate.

## Change

Drop the SSH key entirely and push over HTTPS using the credentials that `actions/checkout` already persists for `GITHUB_TOKEN`, granting the job `contents: write`.

This removes a long-lived credential that has to be rotated by hand and that silently breaks the deploy when it goes missing — exactly what happened here.

Because the job now carries a write-capable token through every step, `rlespinasse/github-slug-action` is pinned to a commit rather than resolved through the mutable `v4.x` tag. The pinned commit is what `v4.x` resolves to today (also tagged `v4.5.0`), so runtime behaviour is unchanged.

## Verification

Both the previous and the new workflow were run on the `ghactions` branch, which the workflow already lists as a deploy target.

- The push to `gh-pages` succeeds and the branch is updated.
- The push starts the GitHub Pages build on its own. For the run whose `Push` step contained no Pages API call at all, exactly one build was created for the pushed commit `301cf839`, attributed to `github-actions[bot]`, finishing with status `built` and no error after 28.9 s.
- The published site under `docs/ghactions/` was refreshed.

An explicit `POST /pages/builds` call was tried during development and then removed: it raced with the build the push had already started and left a spurious failed-build record.

A temporary marker file was used to force a `gh-pages` diff during one run so that the commit and push path was actually exercised; it has since been removed from `gh-pages` and is not part of this branch.

## Known scope limits

`permissions` is scoped per job in GitHub Actions, not per step, so the push credential is present while the documentation is built. Isolating it properly means splitting build and publish into separate jobs and passing the built docs as an artifact. That restructuring is deliberately left out of this change, whose purpose is to make the deploy authenticate at all, and is reasonable follow-up work.

## Follow-up (not in this PR)

The `GH_ACTIONS_DEPLOY_KEY` secret is unused after this change and no longer functional. It can be deleted from the repository settings.

The two failing `Unit` jobs on this branch are unrelated to it: they are the pymatgen `Structure.to` argument-order problem that exists on `develop` and is fixed by #84. This branch only touches `.github/workflows/deploy_docs.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cv7Xn4Q8TSpLjpg9aDpuhi