### PR TITLE
Fix the argument order of Structure.to in the solver tests

### DIFF
--- a/tests/test_aenet.py
+++ b/tests/test_aenet.py
@@ -50,7 +50,10 @@ class TestAENET(unittest.TestCase):
 
     def test_get_results(self):
         res = self.solver.output.get_results(self.datadir)
-        res.structure.to("POSCAR", os.path.join(self.workdir, "pos.vasp"))
+        written = os.path.join(self.workdir, "pos.vasp")
+        res.structure.to(fmt="POSCAR", filename=written)
+        # guards the argument order: a swapped call writes ./POSCAR instead
+        self.assertTrue(os.path.exists(written))
         ref = Structure.from_file(os.path.join(self.datadir, "..", "pos.vasp"))
         ref_energy = -395.21023888
         self.assertTrue(res.structure.matches(ref))

--- a/tests/test_openmx.py
+++ b/tests/test_openmx.py
@@ -58,7 +58,10 @@ class TestOpenMX(unittest.TestCase):
     def test_get_results(self):
         self.solver.input.from_directory(os.path.join(self.datadir, "baseinput"))
         res = self.solver.output.get_results(os.path.join(self.datadir, "output"))
-        res.structure.to("POSCAR", os.path.join(self.workdir, "pos.vasp"))
+        written = os.path.join(self.workdir, "pos.vasp")
+        res.structure.to(fmt="POSCAR", filename=written)
+        # guards the argument order: a swapped call writes ./POSCAR instead
+        self.assertTrue(os.path.exists(written))
         ref = Structure.from_file(os.path.join(self.datadir, "..", "pos.vasp"))
         ref_energy = -119.28626359359154
         self.assertTrue(res.structure.matches(ref))

--- a/tests/test_qe.py
+++ b/tests/test_qe.py
@@ -50,7 +50,10 @@ class TestQE(unittest.TestCase):
 
     def test_get_results(self):
         res = self.solver.output.get_results(self.datadir)
-        res.structure.to("POSCAR", os.path.join(self.workdir, "pos.vasp"))
+        written = os.path.join(self.workdir, "pos.vasp")
+        res.structure.to(fmt="POSCAR", filename=written)
+        # guards the argument order: a swapped call writes ./POSCAR instead
+        self.assertTrue(os.path.exists(written))
         ref = Structure.from_file(os.path.join(self.datadir, "..", "pos.vasp"))
         ref_energy = -1039.9018832347706
         self.assertTrue(res.structure.matches(ref))

--- a/tests/test_vasp.py
+++ b/tests/test_vasp.py
@@ -50,7 +50,10 @@ class TestVASP(unittest.TestCase):
     def test_get_results(self):
         os.utime(os.path.join(self.datadir, "output", "OSZICAR"))
         res = self.solver.output.get_results(os.path.join(self.datadir, "output"))
-        res.structure.to("POSCAR", os.path.join(self.workdir, "pos.vasp"))
+        written = os.path.join(self.workdir, "pos.vasp")
+        res.structure.to(fmt="POSCAR", filename=written)
+        # guards the argument order: a swapped call writes ./POSCAR instead
+        self.assertTrue(os.path.exists(written))
         ref = Structure.from_file(os.path.join(self.datadir, "..", "pos.vasp"))
         ref_energy = 0.54083824
         self.assertTrue(np.isclose(res.energy, ref_energy))


### PR DESCRIPTION
## Problem

The `Unit` job fails on Python 3.13 (both `numpy 1.26.4` and `latest`):

```
ERROR: test_get_results (tests.test_vasp.TestVASP.test_get_results)
  File "tests/test_vasp.py", line 53, in test_get_results
    res.structure.to("POSCAR", os.path.join(self.workdir, "pos.vasp"))
ValueError: Invalid fmt='.../tests/res/vasp/pos.vasp',
valid options are ('cif', 'poscar', 'cssr', 'json', 'yaml', 'yml', 'xsf', 'mcsqs', 'res', 'pwmat', 'aims', '')
```

The same failure occurs in `test_aenet`, `test_openmx`, `test_qe` and `test_vasp`.

## Cause

The four tests call `Structure.to` with the old pymatgen signature `to(fmt, filename)`. Current pymatgen takes `to(filename, fmt)`, so the output path is passed as the format.

The argument order has been wrong for some time. It stayed invisible because pymatgen also selected the POSCAR writer whenever the file name matched `*POSCAR*`; with `filename="POSCAR"` the call succeeded, but it wrote to a file literally named `POSCAR` in the current directory instead of the intended `workdir/pos.vasp`. Every test run therefore left a stray `POSCAR` in the repository root, and the file the tests meant to write was never created.

`pymatgen-core` 2026.8.13, released on 2026-08-13, no longer falls back to that file name match, so the bad format argument now raises. This is why the job started failing without any change on our side, and why it still passes on Python 3.9, where an older pymatgen is resolved.

Library code is not affected: every live `Structure.to` call under `abics/` already passes `fmt` and `filename` by keyword. Only the tests use the positional form.

## Change

Pass both arguments by keyword in the four tests, matching the style used in `abics/`. This is correct on both the old and the new pymatgen, writes the file where the tests intended, and stops littering the working tree.

## Verification

Run in an environment reproducing the CI package set (`pymatgen-core` 2026.8.13 with `pymatgen` 2026.5.4):

- before the change: the same four tests fail with the same `ValueError` as CI
- after the change: 31 tests pass
- with the older `pymatgen-core` 2026.4.16: 31 tests pass, so the change is compatible both ways
- `tests/res/*/pos.vasp` is now actually written, and no stray `POSCAR` appears in the repository root

## Note (not addressed here)

`tests/test_aenetpylammps.py` and `tests/test_aenet.py` share the `tests/res/aenet` directory, and one class's `setUpClass` removes the other's output. Nothing reads those files back, so there is no failure today, but the tests are not isolated from each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cv7Xn4Q8TSpLjpg9aDpuhi