### PR TITLE
Fix NequIP atom type mapping for deployed models

### DIFF
--- a/abics/applications/latgas_abinitio_interface/nequip.py
+++ b/abics/applications/latgas_abinitio_interface/nequip.py
@@ -114,11 +114,23 @@ class NequipSolver(SolverBase):
                 Path to the directory including base input files.
             """
             self.base_input_dir = base_input_dir
-            self.model = torch.jit.load(os.path.join(base_input_dir, "deployed.pth"))
-            yaml_file = os.path.join(base_input_dir, "input.yaml")
-            yaml_dic = Config.from_file(yaml_file)
-            self.element_list = yaml_dic["chemical_symbols"]
-            self.r_max = yaml_dic["r_max"]
+
+            metadata = {
+                "r_max": "",
+                "type_names": "",
+            }
+
+            self.model = torch.jit.load(
+                os.path.join(base_input_dir, "deployed.pth"),
+                _extra_files=metadata,
+            )
+
+            for key, value in metadata.items():
+                if isinstance(value, bytes):
+                    metadata[key] = value.decode()
+
+            self.element_list = metadata["type_names"].split()
+            self.r_max = float(metadata["r_max"])
 
         def update_info_by_structure(self, structure):
             """

--- a/tests/test_nequip.py
+++ b/tests/test_nequip.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import patch
+
+from abics.applications.latgas_abinitio_interface.nequip import NequipSolver
+
+
+class TestNequipSolverInput(unittest.TestCase):
+
+    def test_deployed_type_names_take_precedence_over_chemical_symbols(self):
+        """
+        The atom type ordering used by a deployed NequIP model must come from
+        the deployed model metadata, not from input.yaml chemical_symbols.
+        """
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_input_dir = Path(tmpdir)
+
+            # input.yaml intentionally has a different ordering.
+            (base_input_dir / "input.yaml").write_text(
+                "chemical_symbols:\n"
+                "  - Cu\n"
+                "  - V\n"
+                "  - Sn\n"
+                "r_max: 8.0\n"
+            )
+
+            # torch.jit.load only needs the file path to exist for this mock.
+            (base_input_dir / "deployed.pth").touch()
+
+            dummy_model = object()
+
+            def fake_jit_load(path, _extra_files=None):
+                self.assertEqual(Path(path), base_input_dir / "deployed.pth")
+
+                if _extra_files is not None:
+                    _extra_files["type_names"] = b"V Cu Sn"
+                    _extra_files["r_max"] = b"8.0"
+
+                return dummy_model
+
+            with patch(
+                "abics.applications.latgas_abinitio_interface.nequip.torch.jit.load",
+                side_effect=fake_jit_load,
+            ):
+                solver_input = NequipSolver.Input(ignore_species=None)
+                solver_input.from_directory(str(base_input_dir))
+
+            self.assertIs(solver_input.model, dummy_model)
+            self.assertEqual(solver_input.element_list, ["V", "Cu", "Sn"])
+            self.assertEqual(solver_input.r_max, 8.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Fix NequIP atom type mapping for deployed models

## Summary

This PR fixes the atom type mapping used by the NequIP solver during sampling.

Currently, `NequipSolver.Input.from_directory()` reads the atom type order from:

```python
yaml_dic["chemical_symbols"]
```

in `input.yaml`.

However, with NequIP 0.6.2, the atom type order used internally by the trained and deployed model is stored in `type_names` and may differ from the order of `chemical_symbols`.

For example, the training input may contain:

```yaml
chemical_symbols:
  - Cu
  - V
  - Sn
```

while the trained `config.yaml` contains:

```yaml
type_names:
  - V
  - Cu
  - Sn

type_to_chemical_symbol:
  0: V
  1: Cu
  2: Sn
```

The deployed model metadata also contains:

```text
type_names: V Cu Sn
```

Therefore, the deployed model expects:

```text
V  -> type 0
Cu -> type 1
Sn -> type 2
```

but the current abICS implementation constructs the type indices from `chemical_symbols` and instead uses:

```text
Cu -> type 0
V  -> type 1
Sn -> type 2
```

As a result, Cu and V are evaluated using the wrong atom types, which can produce incorrect energies during sampling.

## Fix

Use `type_names` and `r_max` stored in the metadata of `deployed.pth` instead of reconstructing the atom type mapping from `input.yaml["chemical_symbols"]`.

This ensures that the atom type indices used by abICS are consistent with the mapping actually used by the deployed NequIP model.

## Test

A regression test was added for the case where the order of `chemical_symbols` differs from the deployed model's `type_names`.

The test uses:

```yaml
chemical_symbols:
  - Cu
  - V
  - Sn
```

and mocked deployed-model metadata:

```text
type_names: V Cu Sn
r_max: 8.0
```

and verifies that `NequipSolver.Input.from_directory()` uses:

```python
["V", "Cu", "Sn"]
```

rather than the order in `chemical_symbols`.

The test fails with the previous implementation and passes with this fix.

## Additional verification

The fix was also checked using an actual NequIP 0.6.2 deployed model.

After the change, the energy calculated through the abICS `NequipSolver` agrees with the energy obtained directly using `NequIPCalculator.from_deployed_model()` for the same structure.